### PR TITLE
feat: deleteById()를 제거하여 사용자를 추가로 조회하는 쿼리를 발생하지 않도록 한다.

### DIFF
--- a/src/main/java/com/todobuddy/backend/repository/UserRepository.java
+++ b/src/main/java/com/todobuddy/backend/repository/UserRepository.java
@@ -3,9 +3,15 @@ package com.todobuddy.backend.repository;
 import com.todobuddy.backend.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE User u SET u.deleted = 1 WHERE u.id = :userId")
+    void deleteByIdInQuery(Long userId);
 
 }

--- a/src/main/java/com/todobuddy/backend/service/UserService.java
+++ b/src/main/java/com/todobuddy/backend/service/UserService.java
@@ -110,7 +110,7 @@ public class UserService {
             .toList();
 
         categoryRepository.deleteAllByIdInQuery(categoryIds); // 사용자가 작성한 모든 카테고리 삭제
-        userRepository.deleteById(user.getId()); // 사용자 삭제
+        userRepository.deleteByIdInQuery(user.getId()); // 사용자 삭제
     }
 
     private User findUserByEmail(String email) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #17 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- `deleteById(user.id)`의 경우, user가 존재하는지 `select` 쿼리문을 추가로 발생시킨다. 따라서 `@Query`를 통해 직접 삭제 쿼리를 작성한다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
