### PR TITLE
chore: CI와 CD yml 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,11 +1,9 @@
-name: Deploy To EC2
+name: CD
 
 on:
   push:
     branches:
       - main
-  pull_request:
-    types: [ opened, synchronize, reopened ]
 
 jobs:
   deploy:
@@ -40,8 +38,8 @@ jobs:
         run: aws s3 cp --region ap-northeast-2 ./$GITHUB_SHA.tar.gz s3://${{ secrets.S3_BUCKET_NAME }}/$GITHUB_SHA.tar.gz
 
       - name: Code Deploy를 활용해 EC2에 프로젝트 코드 배포
-        run: aws deploy create-deployment 
-          --application-name ${{ secrets.CODE_DEPLOY_APPLICATION_NAME }} 
-          --deployment-config-name CodeDeployDefault.AllAtOnce 
-          --deployment-group-name ${{ secrets.CODE_DEPLOY_DEVELOPMENT_GROUP }}    
+        run: aws deploy create-deployment
+          --application-name ${{ secrets.CODE_DEPLOY_APPLICATION_NAME }}
+          --deployment-config-name CodeDeployDefault.AllAtOnce
+          --deployment-group-name ${{ secrets.CODE_DEPLOY_DEVELOPMENT_GROUP }}
           --s3-location bucket=${{ secrets.S3_BUCKET_NAME }},bundleType=tgz,key=$GITHUB_SHA.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Github Repository 파일 불러오기
+        uses: actions/checkout@v4
+
+      - name: JDK 17버전 설치
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: MySQL 및 Redis 설정
+        run: docker-compose up -d
+
+      - name: 권한 부여
+        run: chmod +x gradlew
+
+      - name: 테스트 및 빌드하기
+        run: ./gradlew clean build -Plocal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Docker Compose 설치
+        run: |
+          sudo apt-get update
+          sudo apt-get install docker-compose -y
+
       - name: MySQL 및 Redis 설정
         run: docker-compose up -d
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #35 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 기존의 deploy.yml의 경우 PR과 push 시에 두 번의 cicd가 발생하였다. 불필요한 작업이 2번이 발생하므로 CI와 CD를 분리하여 필요한 작업만 하도록 수정한다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
