### PR TITLE
fix: ci.yml에서 트리거 조건을 수정한다.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types: [ opened, synchronize, reopened ]
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #37 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 기존의 ci.yml의 경우 main 브랜치에 push 시에 트리거가 발생하도록 되어 있다. 이것의 문제는 main 브랜치에 push 시에 ci.yml, cd.yml 두 번이 발생하게 된다. 따라서 ci.yml에서 트리거 조건을 수정한다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
