### PR TITLE
chore: static 필드에 @Value 제거

### DIFF
--- a/src/main/java/com/todobuddy/backend/config/CorsConfig.java
+++ b/src/main/java/com/todobuddy/backend/config/CorsConfig.java
@@ -2,39 +2,30 @@ package com.todobuddy.backend.config;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Configuration
 public class CorsConfig {
 
     @Value("${server.domain}")
-    private static String doamin;
+    private String doamin; // static 변수에 @Value를 사용하면 null이 저장된다.
 
-    public static CorsConfigurationSource corsConfiguration() {
+    public CorsConfigurationSource corsConfiguration() {
         CorsConfiguration configuration = new CorsConfiguration();
 
         // allowedOriginPatterns : 리소스를 허용할 URL
-        List<String> allowedOriginPatterns = new ArrayList<>();
-        allowedOriginPatterns.add("http://localhost:3000");
-        allowedOriginPatterns.add("http://127.0.0.1:3000");
-        allowedOriginPatterns.add(doamin);
+        List<String> allowedOriginPatterns = getAllowedOriginPatterns();
 
-        List<String> allowedHttpMethods = new ArrayList<>();
-        allowedHttpMethods.add("GET");
-        allowedHttpMethods.add("POST");
-        allowedHttpMethods.add("PUT");
-        allowedHttpMethods.add("DELETE");
-        allowedHttpMethods.add("PATCH");
-        allowedHttpMethods.add("OPTIONS");
+        // allowedHttpMethods : 허용할 HTTP 메서드
+        List<String> allowedHttpMethods = List.of("GET", "POST", "PUT", "DELETE", "PATCH",
+            "OPTIONS");
 
         configuration.setAllowedOrigins(allowedOriginPatterns);
         configuration.setAllowedMethods(allowedHttpMethods);
-
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
 
@@ -42,5 +33,13 @@ public class CorsConfig {
         source.registerCorsConfiguration("/**", configuration);
 
         return source;
+    }
+
+    private List<String> getAllowedOriginPatterns() {
+        List<String> allowedOriginPatterns = new ArrayList<>();
+        allowedOriginPatterns.add("http://localhost:3000");
+        allowedOriginPatterns.add("http://127.0.0.1:3000");
+        allowedOriginPatterns.add(doamin);
+        return allowedOriginPatterns;
     }
 }

--- a/src/main/java/com/todobuddy/backend/config/SecurityConfig.java
+++ b/src/main/java/com/todobuddy/backend/config/SecurityConfig.java
@@ -22,12 +22,13 @@ public class SecurityConfig {
     private final CustomUserDetailsService customUserDetailsService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final AuthenticationEntryPoint authenticationEntryPoint;
+    private final CorsConfig corsConfig;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
             .cors(cors -> {
-                cors.configurationSource(CorsConfig.corsConfiguration());
+                cors.configurationSource(corsConfig.corsConfiguration());
             })
             .csrf().disable()
             .headers(headers -> headers.frameOptions().disable())


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #86 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- static 필드에 @Value를 사용하는 경우 null이 저장되므로, 도메인 값이  저장되지 않는 문제가 발생합니다.
- CorsConfig클래스가 static임에 따라, domain 필드를 static으로 사용하였습니다. static 필드를 사용하지 않기 위해 클래스에서 static을 제거합니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
