### PR TITLE
fix: Bearer를 포함하지 않는 리프레시 토큰 사용

### DIFF
--- a/src/main/java/com/todobuddy/backend/service/AuthService.java
+++ b/src/main/java/com/todobuddy/backend/service/AuthService.java
@@ -24,14 +24,14 @@ public class AuthService {
     @Transactional
     public AuthResponse refreshToken(String refreshToken) {
         try {
-            String extractBearerToken = extractBearerToken(refreshToken);
-            Claims claims = jwtTokenProvider.validateToken(extractBearerToken); // Refresh Token 유효성 검사
+            String extractRefreshToken = extractBearerToken(refreshToken);
+            Claims claims = jwtTokenProvider.validateToken(extractRefreshToken); // Refresh Token 유효성 검사
             String email = claims.getSubject(); // Refresh Token에서 이메일 추출
 
             User findUser = findUserByEmail(email);
 
             String newAccessToken = jwtTokenProvider.generateAccessToken(findUser); // 새로운 Access Token 발급
-            return new AuthResponse(newAccessToken, extractBearerToken, jwtTokenProvider.getExpirationDateFromToken(refreshToken), "Bearer");
+            return new AuthResponse(newAccessToken, extractRefreshToken, jwtTokenProvider.getExpirationDateFromToken(extractRefreshToken), "Bearer");
         } catch (ExpiredJwtException e) { // Refresh Token 만료
             throw new TokenExpiredException(JwtErrorCode.EXPIRED_TOKEN);
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #90 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. 기존에 "Bearer "를 포함하는 Refresh Token을 전달하는 문제가 있었다.
2. 1번의 리프레시 토큰의 payload를 파싱하는 과정에서 토큰이 올바르지 않는 오류가 발생한다.
3. 오류가 발생하는 이유는 eyJ~.eyJ.adsad~ 이런식의 리프레시 토큰을 파싱하길 기대하는데, Bearer eyJ~.eyJ.adsad~ 형태의 토큰을 파싱하지 못하기 때문에 오류가 발생

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
