### PR TITLE
fix: prod환경에서 aws 자격 증명 정보 추가

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -50,3 +50,9 @@ aws:
     prefix: /config
     profile-separator: _
     name: todobuddy
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS.ACCESS.KEY}
+      secret-key: ${AWS.SECRET.KEY}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #94 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- EC2에 배포된 prod환경에서 logging을 위한 logback-spring.xml에 AWS 자격 증명 정보가 추가되지 않던 문제를 수정합니다.
- `<springProperty name="AWS_ACCESS_KEY" source="cloud.aws.credentials.access-key"/>` source로 참조하기 위해서는 `application.yml`에 작성해야 한다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
