### PR TITLE
Feat/#96 reissue access token

### DIFF
--- a/src/main/java/com/todobuddy/backend/controller/AuthController.java
+++ b/src/main/java/com/todobuddy/backend/controller/AuthController.java
@@ -6,7 +6,9 @@ import com.todobuddy.backend.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @Tag(name = "Auth", description = "Auth API")
+@SecurityRequirement(name = "bearerAuth")
 public class AuthController {
 
     private final AuthService authService;
@@ -27,9 +30,9 @@ public class AuthController {
         @ApiResponse(responseCode = "201", description = "Access Token 재발급 성공")
     })
     @PostMapping("/reissue")
-    public Response<AuthResponse> refreshToken(
-        @RequestHeader("Authorization") String refreshToken) {
-        AuthResponse response = authService.refreshToken(refreshToken);
+    public Response<AuthResponse> refreshToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        AuthResponse response = authService.refreshToken(authorization);
         return Response.of(HttpStatus.CREATED, response);
     }
 }

--- a/src/main/java/com/todobuddy/backend/service/AuthService.java
+++ b/src/main/java/com/todobuddy/backend/service/AuthService.java
@@ -22,9 +22,9 @@ public class AuthService {
     private final UserRepository userRepository;
 
     @Transactional
-    public AuthResponse refreshToken(String refreshToken) {
+    public AuthResponse refreshToken(String authorization) {
         try {
-            String extractRefreshToken = extractBearerToken(refreshToken);
+            String extractRefreshToken = extractBearerToken(authorization);
             Claims claims = jwtTokenProvider.validateToken(extractRefreshToken); // Refresh Token 유효성 검사
             String email = claims.getSubject(); // Refresh Token에서 이메일 추출
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -41,4 +41,4 @@ jwt:
   refresh-token-expiration-time: ${JWT_REFRESH_EXPIRATION_TIME}
   issuer: ${JWT_ISSUER}
 
-server.domain: "localhost"
+server.domain: "http://localhost:8080"


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #96 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. 로컬환경에서 스웨거를 사용할 때, 요청이 도달하는 서버 주소 변경한다. 기존의 `localhost`를 사용하는 경우, 서버로 요청이 도달하지 않는다.
`localhost` -> `http://localhost:8080`
![스크린샷 2024-09-03 오전 2 19 10](https://github.com/user-attachments/assets/9c216cdc-b98f-425e-97fe-4df78e06571b)
2. 스웨거에서 요청을 보냈을 때, @RequestHeader를 사용하여 헤더에 담긴 토큰이 가져와지지 않는 문제가 발생하였다. 따라서 @RequestHeader가 아닌 HttpServletRequest를 사용하여 요청에 담긴 Authroization 헤더를 직접 가져오도록 수정한다.



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
